### PR TITLE
Add support for alt text

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,6 +14,7 @@ describe('enhancedImages plugin', () => {
 
     expect(compiled?.code).toContain('<enhanced:img')
     expect(compiled?.code).toContain(`"./image.jpg"`)
+    expect(compiled?.code).toContain(`alt="Alt text"`)
   })
 
   test(`path aliases are preserved`, async () => {
@@ -21,6 +22,7 @@ describe('enhancedImages plugin', () => {
     const compiled = await _compile(markdown)
 
     expect(compiled?.code).toContain(`"$images/image.jpg"`)
+    expect(compiled?.code).toContain(`alt="Alt text"`)
   })
 
   test(`relative paths are preserved`, async () => {
@@ -28,6 +30,16 @@ describe('enhancedImages plugin', () => {
     const compiled = await _compile(markdown)
 
     expect(compiled?.code).toContain(`"../image.jpg"`)
+    expect(compiled?.code).toContain(`alt="Alt text"`)
+  })
+
+  test('handles empty alt text', async () => {
+    const markdown = '![](image.jpg)'
+    const compiled = await _compile(markdown)
+
+    expect(compiled?.code).toContain('<enhanced:img')
+    expect(compiled?.code).toContain(`"./image.jpg"`)
+    expect(compiled?.code.includes('alt')).toBe(false)
   })
 
   test(`handles frontmatter`, async () => {
@@ -55,5 +67,6 @@ published: true
     )
     expect(compiled?.code).toContain('<enhanced:img')
     expect(compiled?.code).toContain('./image.jpg')
+    expect(compiled?.code).toContain(`alt="Alt text"`)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,12 @@ export const enhancedImages: Plugin<[Partial<Config>?], any> = (config) => {
     visit<any, Test>(tree, 'image', (node, index, parent) => {
       const url = resolvedConfig.resolve(node.url)
       node.type = 'html'
-      node.value = `<enhanced:img src="${url}" />`
+      if (node.alt !== null) {
+        node.value = `<enhanced:img src="${url}" alt="${node.alt}" />`
+      }
+      else {
+        node.value = `<enhanced:img src="${url}" />`
+      }
     })
 
     // console.error(`***tree out`, JSON.stringify(tree, null, 2))


### PR DESCRIPTION
Close #2 

I don't think there are other properties that can be specified through markdown and should therefore mapped. I see there's a `title` property on the image node but it's always null, apparently.