### PR TITLE
Update enhanced-img version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@s-libs/micro-dash": "^18.0.0",
-    "@sveltejs/enhanced-img": "^0.3.8",
+    "@sveltejs/enhanced-img": "^0.4.4",
     "@types/bun": "latest",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",


### PR DESCRIPTION
I updated the enhanced-img version to ^0.4.4.

I tested `test-app` locally and it seems to work fine. I also checked the `enhanced-img` release notes and the only breaking change is the update to Svelte 5.