### PR TITLE
fixed defaultResolverFactory to include URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ export const defaultResolverFactory =
   (relativeHandler = (path: string) => `.${sep}${path}`) =>
   (path: string) => {
     if (
+      path.startsWith('http://') ||
+      path.startsWith('https://') ||
       path.startsWith('$') ||
       path.startsWith('@') ||
       path.startsWith(`.${sep}`) ||


### PR DESCRIPTION
Missed this part of the equation! Couldn't really catch it when I was working all on my machine.

<img width="1376" alt="Screenshot 2025-02-26 at 5 44 26 PM" src="https://github.com/user-attachments/assets/dc7865f1-5b5b-410e-b807-001d02777436" />
