### PR TITLE
fix: forgotten dependency (unified) in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "prettier": "^3.4.2",
     "prettier-plugin-organize-imports": "^4.1.0",
     "tsup": "^8.3.6",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "unified": "^11.0.5"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Attempted to build the lib from source (`npm i && npm run build`)

Got 
```
ESM dist/index.js 2.05 KB
ESM ⚡️ Build success in 47ms
DTS Build start
src/index.ts(3,29): error TS2307: Cannot find module 'unified' or its corresponding type declarations.
src/index.ts(36,65): error TS7006: Parameter 'config' implicitly has an 'any' type.
```

After doing ` npm i unified -D` the build passes.

**Important:**  
I could not verify if this dep (`unified`) is present in the used lockfile `bun.lockb` (as it's binary and I don't have bun on my machine RN). You may want to check if it's the case, and possibly update the lockfile.